### PR TITLE
fix: gender colors on Courtesy Turn

### DIFF
--- a/assets/b1/courtesy_turn.xml
+++ b/assets/b1/courtesy_turn.xml
@@ -53,8 +53,8 @@
   <tam title="Courtesy Turn" from="Girls facing Boys" sequencer="gender-specific">
     <formation>
       <dancer gender="boy" x="1" y="3" angle="270"/>
-      <dancer gender="boy" x="-1" y="3" angle="270"/>
       <dancer gender="girl" x="1" y="1" angle="90"/>
+      <dancer gender="boy" x="-1" y="3" angle="270"/>
       <dancer gender="girl" x="-1" y="1" angle="90"/>
     </formation>
     <path>
@@ -62,12 +62,12 @@
       <move select="Beau Wheel" scaleX="0.5" scaleY="1.25"/>
     </path>
     <path>
-      <move select="U-Turn Left" offsetX="1" offsetY="-0.5"/>
-      <move select="Beau Wheel" scaleX="0.5" scaleY="0.25"/>
-    </path>
-    <path>
       <move select="Extend Right" beats="3" scaleY="0.5"/>
       <move select="Belle Wheel" scaleX="0.5" scaleY="0.25"/>
+    </path>
+    <path>
+      <move select="U-Turn Left" offsetX="1" offsetY="-0.5"/>
+      <move select="Beau Wheel" scaleX="0.5" scaleY="0.25"/>
     </path>
     <path>
       <move select="Extend Right" beats="3" scaleY="0.5"/>


### PR DESCRIPTION
Fixes #260 (I think)

Begin:
<img width="216" alt="ct-begin" src="https://user-images.githubusercontent.com/49817386/161448401-b8c424cb-1e4f-409a-a29a-4c6088f31628.png">

Midpoint:
<img width="268" alt="ct-midpoint" src="https://user-images.githubusercontent.com/49817386/161448410-ace6a47c-2d33-4fad-9b23-b8abc1a9ff7c.png">

End:
<img width="163" alt="ct-end" src="https://user-images.githubusercontent.com/49817386/161448413-369a5d03-2cc6-4925-814b-06c0feb45d33.png">

LMK if there's anything else I need to do.

