### PR TITLE
Fixes #270: regroup SCT from 8CT

### DIFF
--- a/assets/ms/spin_chain_thru.xml
+++ b/assets/ms/spin_chain_thru.xml
@@ -70,7 +70,7 @@
     </path>
   </tam>
 
-  <tam title="Spin Chain Thru" group=" "
+  <tam title="Spin Chain Thru"
        from="Eight Chain Thru"
        formation="Eight Chain Thru"
        parts="5;4.5;3" difficulty="2">


### PR DESCRIPTION
Fixes #270 

<img width="879" alt="Screen Shot 2022-05-21 at 12 24 24 PM" src="https://user-images.githubusercontent.com/49817386/169666420-be7827da-a5e2-40e0-ad75-e5a4713f5f92.png">

I think this is expected.