### PR TITLE
ignore ios/Podfile

### DIFF
--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -24,6 +24,7 @@ Flutter/flutter_assets/
 Flutter/flutter_export_environment.sh
 ServiceDefinitions.json
 Runner/GeneratedPluginRegistrant.*
+Podfile
 
 # Exceptions to above rules.
 !default.mode1v3


### PR DESCRIPTION
After running `flutter build`, I get a podfile:
```
On branch spin-chain-thru-group
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   assets/ms/spin_chain_thru.xml

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	ios/Podfile

no changes added to commit (use "git add" and/or "git commit -a")
```

This change to .gitignore ignores the generated Podfile so it doesn't show as "untracked" and accidentally get committed.