### PR TITLE
Fixes #273: images don't load from ssd

### DIFF
--- a/lib/pages/markdown_page.dart
+++ b/lib/pages/markdown_page.dart
@@ -216,7 +216,9 @@ class _MarkdownFrameState extends fm.State<MarkdownFrame> {
     //  Title is uppercase
         .replaceAllMapped('^# (.*)'.rm,(m) => '# ${m[1]!.toUpperCase()}')
     //  Fix image links
-        .replaceAll('![alt](','![alt](resource:assets/$_dir/')
+        .replaceAllMapped(
+          r'!\[alt\]\(([^)]*)'.rm,
+          (m) => '![alt](resource:assets/${TamUtils.linkSSD('${_dir}/${m[1]!}')}')
     //  Interpret encodings
         .replaceAll('\\<','<')
     //  Highlight current part


### PR DESCRIPTION
fixes #273 

Images don't load when selecting the call from the SSD page. With this change, the links are rewritten as expected.