### PR TITLE
Add Center 6 Walk and Dodge

### DIFF
--- a/assets/ms/walk_and_dodge.xml
+++ b/assets/ms/walk_and_dodge.xml
@@ -243,7 +243,7 @@
     </path>
   </tam>
 
-  <tam title="Center 6 Walk and Dodge" from="Mixed Quarter Tag 1" formation="Mixed Quarter Tag #3" difficulty="3">
+  <tam title="Center 6 Walk and Dodge" from="Mixed Quarter Tag 1" formation="Mixed Quarter Tag #2" difficulty="3">
     <path>
       <move select="Forward 3" beats="4" />
     </path>
@@ -258,7 +258,35 @@
     </path>
   </tam>
 
-  <tam title="Center 6 Walk and Dodge" from="Mixed Quarter Tag 2" formation="Mixed Quarter Tag #8" difficulty="3">
+  <tam title="Center 6 Walk and Dodge" from="Mixed Quarter Tag 2" formation="Mixed Quarter Tag #3" difficulty="3">
+    <path>
+      <move select="Forward 3" beats="4" />
+    </path>
+    <path>
+      <move select="Dodge Right" beats="4" />
+    </path>
+    <path>
+      <!-- do nothing -->
+    </path>
+    <path>
+      <move select="Forward 3" beats="4" />
+    </path>
+  </tam>
+  <tam title="Center 6 Walk and Dodge" from="Mixed Quarter Tag 3" formation="Mixed Quarter Tag #5" difficulty="3">
+    <path>
+      <move select="Dodge Left" beats="4" />
+    </path>
+    <path>
+      <move select="Forward 3" beats="4" />
+    </path>
+    <path>
+      <!-- do nothing -->
+    </path>
+    <path>
+      <move select="Forward 3" beats="4" />
+    </path>
+  </tam>
+  <tam title="Center 6 Walk and Dodge" from="Mixed Quarter Tag 4" formation="Mixed Quarter Tag #8" difficulty="3">
     <path>
       <move select="Dodge Left" beats="4" />
     </path>

--- a/assets/ms/walk_and_dodge.xml
+++ b/assets/ms/walk_and_dodge.xml
@@ -301,6 +301,65 @@
     </path>
   </tam>
 
+
+  <tam title="Outside 6 Walk and Dodge" from="Mixed Quarter Tag 1" formation="Mixed Quarter Tag #1" sequencer="perimeter" difficulty="3">
+    <path>
+      <move select="Extend Left" beats="4" scaleX="3" scaleY="2"/>
+    </path>
+    <path>
+      <move select="Dodge Right" beats="4" />
+    </path>
+    <path>
+      <move select="Extend Right" beats="4" scaleX="3" scaleY="2"/>
+    </path>
+    <path>
+      <!-- do nothing -->
+    </path>
+  </tam>
+
+  <tam title="Outside 6 Walk and Dodge" from="Mixed Quarter Tag 2" formation="Mixed Quarter Tag #3" sequencer="perimeter" difficulty="3">
+    <path>
+      <move select="Extend Left" beats="4" scaleX="3" scaleY="2"/>
+    </path>
+    <path>
+      <move select="Dodge Right" beats="4" />
+    </path>
+    <path>
+      <move select="Extend Right" beats="4" scaleX="3" scaleY="2"/>
+    </path>
+    <path>
+      <!-- do nothing -->
+    </path>
+  </tam>
+  <tam title="Outside 6 Walk and Dodge" from="Mixed Quarter Tag 3" formation="Mixed Quarter Tag #6" sequencer="perimeter" difficulty="3">
+    <path>
+      <move select="Dodge Left" beats="4" />
+    </path>
+    <path>
+      <move select="Extend Right" beats="4" scaleX="3" scaleY="2"/>
+    </path>
+    <path>
+      <move select="Extend Left" beats="4" scaleX="3" scaleY="2"/>
+    </path>
+    <path>
+      <!-- do nothing -->
+    </path>
+  </tam>
+  <tam title="Outside 6 Walk and Dodge" from="Mixed Quarter Tag 4" formation="Mixed Quarter Tag #8" sequencer="perimeter" difficulty="3">
+    <path>
+      <move select="Dodge Left" beats="4" />
+    </path>
+    <path>
+      <move select="Extend Right" beats="4" scaleX="3" scaleY="2"/>
+    </path>
+    <path>
+      <move select="Extend Left" beats="4" scaleX="3" scaleY="2"/>
+    </path>
+    <path>
+      <!-- do nothing -->
+    </path>
+  </tam>
+
   <tam title="3 by 1 Walk and Dodge" group=" "
        difficulty="3">
      <formation>

--- a/assets/ms/walk_and_dodge.xml
+++ b/assets/ms/walk_and_dodge.xml
@@ -243,6 +243,36 @@
     </path>
   </tam>
 
+  <tam title="Center 6 Walk and Dodge" from="Mixed Quarter Tag 1" formation="Mixed Quarter Tag #3" difficulty="3">
+    <path>
+      <move select="Forward 3" beats="4" />
+    </path>
+    <path>
+      <move select="Dodge Right" beats="4" />
+    </path>
+    <path>
+      <!-- do nothing -->
+    </path>
+    <path>
+      <move select="Forward 3" beats="4" />
+    </path>
+  </tam>
+
+  <tam title="Center 6 Walk and Dodge" from="Mixed Quarter Tag 2" formation="Mixed Quarter Tag #8" difficulty="3">
+    <path>
+      <move select="Dodge Left" beats="4" />
+    </path>
+    <path>
+      <move select="Forward 3" beats="4" />
+    </path>
+    <path>
+      <!-- do nothing -->
+    </path>
+    <path>
+      <move select="Forward 3" beats="4" />
+    </path>
+  </tam>
+
   <tam title="3 by 1 Walk and Dodge" group=" "
        difficulty="3">
      <formation>
@@ -285,5 +315,6 @@
       <move select="Forward 2" beats="4" />
     </path>
   </tam>
+
 
 </tamination>


### PR DESCRIPTION
Partial fix for #72 . The following sequences now work:

1. Sides Pass the Ocean; Sides Swing Thru; Boys Run; Center 6 Walk and Dodge
2. Sides Pass the Ocean; Sides Swing Thru; Girls Run; Center 6 Walk and Dodge

The completed formation is recognized and can be used to "get out" -- for example, "Centers Bend the Line" works after the call.

<img width="423" alt="Screen Shot 2022-05-21 at 3 16 27 PM" src="https://user-images.githubusercontent.com/49817386/169670670-e7cf7856-74b0-4262-8456-9310f81cbda3.png">

Wasn't sure what to put for "difficulty". 

I used "Mixed Quarter Tag 1" because C1 Recycle and Inlet use versions without the number-signs. Linear Action uses the number-signs but also has variants for all 8 arrangements.