### PR TITLE
C3A markdown fixups

### DIFF
--- a/assets/c3a/anythingers_couple_up.md
+++ b/assets/c3a/anythingers_couple_up.md
@@ -1,10 +1,10 @@
 
-# &lt;anything>er's Couple Up
+# \<anything>er's Couple Up
 
 **Parts:** 2  
 
-From any applicable formation: Do the &lt;anything> call, then the Leaders U-Turn Back.
-If the &lt;anything> is a type of Circulate or Counter Rotate,
+From any applicable formation: Do the \<anything> call, then the Leaders U-Turn Back.
+If the \<anything> is a type of Circulate or Counter Rotate,
 it may be abbreviated in the same way as for the "anything concept" [C-2],
 e.g. "Inroll Couple Up" or "Split Counter Couple Up".
 

--- a/assets/c3a/central_concept.md
+++ b/assets/c3a/central_concept.md
@@ -16,10 +16,10 @@ Little More”, “Central Stampede”, “Central Team Up”, and “Central Ea
 because the original Centers remain Centers, and the Cloverleaf paths do not include
 interacting with Ends.
 
-If the starting setup is a 2x4, then Central &lt;anything> is done either in each Box or in each
+If the starting setup is a 2x4, then Central \<anything> is done either in each Box or in each
 1x4. In most cases, only one of these possibilities will work. For example, “Central Cross
 Ramble” starts with a Cross Fold action and thus requires working in each wave. If Central
-&lt;anything> can be done in either a Box or a 1x4, then it should be done in each Box unless
+\<anything> can be done in either a Box or a 1x4, then it should be done in each Box unless
 the caller specifies otherwise. For example, from Parallel Waves, “Central Detour” is the
 same as Split Counter Rotate, but “Each Wave Central Detour” is the same as Lockit.
 
@@ -34,9 +34,9 @@ dancers, the caller should specify the desired 4-person setup explicitly, using 
 > 
 
 *The following section discusses technical details
-about appropriate &lt;anything> calls. This is
+about appropriate \<anything> calls. This is
 primarily intended to clarify the criteria
-that a caller should use in selecting the &lt;anything> call.*
+that a caller should use in selecting the \<anything> call.*
 
 
 It is not proper to apply the Central concept to such calls as Reverse Cut/Flip the Galaxy,


### PR DESCRIPTION
Minor typographical issue; `&lt;` was not converted to `<` in the markdown correctly. 

Before (Chrome, also reproed on iOS):
<img width="417" alt="Screen Shot 2022-07-03 at 10 35 07 AM" src="https://user-images.githubusercontent.com/49817386/177051075-c632d5d7-f669-4632-a796-b00776e644bc.png">

After:
<img width="374" alt="Screen Shot 2022-07-03 at 10 35 28 AM" src="https://user-images.githubusercontent.com/49817386/177051078-f23bb18b-310c-4b73-a50d-d647f44a1887.png">


I escaped them using `\<` because it was like that some places (but not others). Not sure what the correct answer is since I haven't tested on all platforms.