### PR TITLE
Controversial: Relabel SSD

### DIFF
--- a/lib/pages/level_page.dart
+++ b/lib/pages/level_page.dart
@@ -190,7 +190,7 @@ class LevelFrame extends fm.StatelessWidget {
                 text:'Basic and Mainstream' ,
                 background:Color.BMS),
             _IndentedLineWidget(
-                text:'SSD' ,
+                text:'Social (SSD)' ,
                 background:Color.MS,
                 indented:Color.BMS),
             _IndentedLineWidget(


### PR DESCRIPTION
Acronyms can frequently be jargon and esoteric. I understand why Callerlab treats "SSD" as an acronym, and everyone says "SSD". However, this is the only acronym actively in use that new dancers may encounter. ("A" and "C" are frequently referred to by their initials, but even in this program their names are spelled out. "APD" and "DBD" are not usually terms new dancers would encounter.)

As a new dancer myself, I believe that we should discourage the use of acronyms. I also would like to encourage the use of the word "Social": It's a much clearer way of describing the program and it doesn't have the redundancy of being "Social Square Dancing" within "Square Dancing" itself.

<img width="309" alt="Screen Shot 2022-07-03 at 11 21 32 AM" src="https://user-images.githubusercontent.com/49817386/177052479-f47ce8ca-9555-4fa2-8fec-1b3c04b92dfb.png">

I'm not married to this change and I know it's controversial. I don't intend to change anything else with this revision - only the label.

Since SSD contains almost all of Basic and overlaps Mainstream, I'm wondering if we should order Basic 1 - Basic 2 - Social (SSD) - Mainstream