### PR TITLE
fixes #231: Press Ahead from Columns to Triple Boxes

### DIFF
--- a/assets/c1/press.xml
+++ b/assets/c1/press.xml
@@ -109,6 +109,36 @@
     </path>
   </tam>
 
+  <tam title="Press Ahead" from="Right-Hand Columns" formation="Columns">
+    <path>
+      <move select="Forward 2" hands="left"/>
+    </path>
+    <path>
+      <move select="Forward 2" hands="right"/>
+    </path>
+    <path>
+      <move select="Forward 2" hands="right"/>
+    </path>
+    <path>
+      <move select="Forward 2" hands="left"/>
+    </path>
+  </tam>
+
+  <tam title="Press Ahead" from="Left-Hand Columns" formation="Column LH GBGB">
+    <path>
+      <move select="Forward 2" hands="left"/>
+    </path>
+    <path>
+      <move select="Forward 2" hands="right"/>
+    </path>
+    <path>
+      <move select="Forward 2" hands="right"/>
+    </path>
+    <path>
+      <move select="Forward 2" hands="left"/>
+    </path>
+  </tam>
+
   <tam title="Ends Press Ahead" group=" "
        from="Lines Facing Out">
      <formation>


### PR DESCRIPTION
Fixes #231 ... I think. If triple boxes is a 6x2 formation, then it _seems_ like this is the correct answer. I also compared it to the wave variants, and it seems analogous. This result also reminds me of Circulate from Columns meaning you skip one dancer to the next.

<img width="791" alt="Screen Shot 2022-07-03 at 12 51 01 PM" src="https://user-images.githubusercontent.com/49817386/177055216-6e872edd-0798-473a-863f-07e460ffc9af.png">
.