### PR TITLE
Set minimum url_launcher

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   shared_preferences: ^2.0.0
   speech_to_text: ^5.0.0
   tuple: ^2.0.0
-  url_launcher: ^6.0.4
+  url_launcher: ^6.1.5
   xml: ^6.1.0
 
 dev_dependencies:


### PR DESCRIPTION
Changes made in 716fde4b1bb1c50a25ac9ce1debed70da9d40dc1 (from `launch` to `launchUrl`) require `url_launcher` of at least 6.1.0. My `pubspec.lock` was out-of-date. Since 6.1.5 is the latest, I just made that the minimum.

Please consider committing the `pubspec.lock` file. It's more maintenance, but it would prevent multiple developers testing with out-of-sync packages, and it would ensure reproducible builds. Per the [dart documentation](https://dart.dev/tools/pub/glossary#lockfile):

> If your package is an application package, you will typically check this into source control. For library packages, you usually won’t.