### PR TITLE
"All 8" and "All 4 Couples" are A-2 usages

### DIFF
--- a/assets/a1/cross_trail_thru.xml
+++ b/assets/a1/cross_trail_thru.xml
@@ -135,6 +135,6 @@
 
   <tamxref title="All 4 Couples Cross Trail Thru" group=" "
            xref-link="a2/all_4_all_8"
-           xref-title="All 4 Couples (A-1) Cross Trail Thru"/>
+           xref-title="All 4 Couples (A-2) Cross Trail Thru"/>
 
 </tamination>

--- a/assets/a1/double_star_thru.xml
+++ b/assets/a1/double_star_thru.xml
@@ -101,9 +101,9 @@
   </tam>
 
 
-  <tamxref title="All 4 Couples (A-1) Double Star Thru" group=" "
+  <tamxref title="All 4 Couples (A-2) Double Star Thru" group=" "
            xref-link="a2/all_4_all_8"
-           xref-title="All 4 Couples (A-1) Double Star Thru"/>
+           xref-title="All 4 Couples (A-2) Double Star Thru"/>
 
   <tam title="Triple Star Thru"
        from="Double Pass Thru"

--- a/assets/a1/lock_it.xml
+++ b/assets/a1/lock_it.xml
@@ -375,7 +375,7 @@
 
   <tamxref title="All 8 Lockit" group=" "
            xref-link="a2/all_4_all_8"
-           xref-title="All 8 (A-1) Lockit"
+           xref-title="All 8 (A-2) Lockit"
            xref-formation="Thar LH Boys"/>
 
 </tamination>

--- a/assets/a1/mix.xml
+++ b/assets/a1/mix.xml
@@ -482,7 +482,7 @@
 
   <tamxref title="All 8 Mix" group=" "
            xref-link="a2/all_4_all_8"
-           xref-title="All 8 (A-1) Mix"
+           xref-title="All 8 (A-2) Mix"
            xref-formation="Thar RH Boys"/>
 
   <tam title="As Couples Mix"

--- a/assets/a1/pair_off.xml
+++ b/assets/a1/pair_off.xml
@@ -123,6 +123,6 @@
 
   <tamxref title="All 4 Couples Pair Off" group=" "
            xref-link="a2/all_4_all_8"
-           xref-title="All 4 Couples (A-1) Pair Off"/>
+           xref-title="All 4 Couples (A-2) Pair Off"/>
 
 </tamination>

--- a/assets/a1/pass_in.xml
+++ b/assets/a1/pass_in.xml
@@ -135,7 +135,7 @@
 
   <tamxref title="All 4 Couples Pass In" group=" "
            xref-link="a2/all_4_all_8"
-           xref-title="All 4 Couples (A-1) Pass In"/>
+           xref-title="All 4 Couples (A-2) Pass In"/>
 
   <tam title="Pass Out"
        from="Facing Couples"
@@ -251,6 +251,6 @@
 
   <tamxref title="All 4 Couples Pass Out" group=" "
            xref-link="a2/all_4_all_8"
-           xref-title="All 4 Couples (A-1) Pass Out"/>
+           xref-title="All 4 Couples (A-2) Pass Out"/>
 
 </tamination>

--- a/assets/a1/pass_the_sea.xml
+++ b/assets/a1/pass_the_sea.xml
@@ -134,6 +134,6 @@
 
   <tamxref title="All 4 Couples Pass the Sea" group=" "
            xref-link="a2/all_4_all_8"
-           xref-title="All 4 Couples (A-1) Pass the Sea"/>
+           xref-title="All 4 Couples (A-2) Pass the Sea"/>
 
 </tamination>

--- a/assets/a1/quarter_in.xml
+++ b/assets/a1/quarter_in.xml
@@ -213,7 +213,7 @@
 
   <tamxref title="All 4 Couples Quarter In" group=" "
            xref-link="a2/all_4_all_8"
-           xref-title="All 4 Couples (A-1) Quarter In"/>
+           xref-title="All 4 Couples (A-2) Quarter In"/>
 
   <tam title="As Couples Quarter In"
        from="Lines"
@@ -402,7 +402,7 @@
 
   <tamxref title="All 4 Couples Quarter Out" group=" "
            xref-link="a2/all_4_all_8"
-           xref-title="All 4 Couples (A-1) Quarter Out"/>
+           xref-title="All 4 Couples (A-2) Quarter Out"/>
 
   <tam title="As Couples Quarter Out"
        from="Lines"

--- a/assets/a1/quarter_thru.xml
+++ b/assets/a1/quarter_thru.xml
@@ -290,7 +290,7 @@
 
   <tamxref title="All 8 Quarter Thru" group=" "
            xref-link="a2/all_4_all_8"
-           xref-title="All 8 (A-1) Quarter Thru"/>
+           xref-title="All 8 (A-2) Quarter Thru"/>
 
   <tam title="3/4 Thru"
        from="Right-Hand Box"
@@ -538,6 +538,6 @@
 
   <tamxref title="All 8 3/4 Thru" group=" "
            xref-link="a2/all_4_all_8"
-           xref-title="All 8 (A-1) 3/4 Thru"/>
+           xref-title="All 8 (A-2) 3/4 Thru"/>
 
 </tamination>

--- a/assets/a1/right_roll_to_a_wave.xml
+++ b/assets/a1/right_roll_to_a_wave.xml
@@ -326,7 +326,7 @@
   <tamxref title="All 8 Right Roll to a Wave" group=" "
            xref-link="a2/all_4_all_8"
            xref-from="Couples Facing Out"
-           xref-title="All 8 (A-1) Right Roll to a Wave"/>
+           xref-title="All 8 (A-2) Right Roll to a Wave"/>
 
   <tam title="Left Roll to a Wave"
        from="Couples Facing Out"
@@ -617,7 +617,7 @@
 
   <tamxref title="All 8 Left Roll to a Wave" group=" "
            xref-link="a2/all_4_all_8"
-           xref-title="All 8 (A-1) Left Roll to a Wave"
+           xref-title="All 8 (A-2) Left Roll to a Wave"
            xref-formation="Static Facing Out"/>
 
 </tamination>

--- a/assets/a1/scoot_and_dodge.xml
+++ b/assets/a1/scoot_and_dodge.xml
@@ -163,6 +163,6 @@
   <tamxref title="All 8 Scoot and Dodge" group=" "
            xref-link="a2/all_4_all_8"
            xref-from="Static Mini-Waves"
-           xref-title="All 8 (A-1) Scoot and Dodge"/>
+           xref-title="All 8 (A-2) Scoot and Dodge"/>
 
 </tamination>

--- a/assets/a1/square_chain_thru.xml
+++ b/assets/a1/square_chain_thru.xml
@@ -247,7 +247,7 @@
 
   <tamxref title="All 4 Couples Square Chain Thru" group=" "
            xref-link="a2/all_4_all_8"
-           xref-title="All 4 Couples (A-1) Square Chain Thru"/>
+           xref-title="All 4 Couples (A-2) Square Chain Thru"/>
 
   <tam title="Left Square Chain Thru"
        from="Facing Couples"

--- a/assets/a1/swap_around.xml
+++ b/assets/a1/swap_around.xml
@@ -130,7 +130,7 @@
 
   <tamxref title="All 8 Swap Around" group=" "
            xref-link="a2/all_4_all_8"
-           xref-title="All 8 (A-1) Swap Around"/>
+           xref-title="All 8 (A-2) Swap Around"/>
 
   <tam title="Reverse Swap Around"
        from="Facing Couples"
@@ -240,6 +240,6 @@
 
   <tamxref title="All 8 Reverse Swap Around" group=" "
            xref-link="a2/all_4_all_8"
-           xref-title="All 8 (A-1) Reverse Swap Around"/>
+           xref-title="All 8 (A-2) Reverse Swap Around"/>
 
 </tamination>

--- a/assets/a1/turn_and_deal.xml
+++ b/assets/a1/turn_and_deal.xml
@@ -585,25 +585,25 @@
   <tamxref title="All 8 Turn and Deal"
            from="Thar"
            xref-link="a2/all_4_all_8"
-           xref-title="All 8 (A-1) Turn and Deal"
+           xref-title="All 8 (A-2) Turn and Deal"
            xref-formation="Thar RH Boys"/>
 
   <tamxref title="All 8 Turn and Deal"
            from="Wrong Way Thar"
            xref-link="a2/all_4_all_8"
-           xref-title="All 8 (A-1) Turn and Deal"
+           xref-title="All 8 (A-2) Turn and Deal"
            xref-formation="Thar LH Boys"/>
 
   <tamxref title="All 8 Turn and Deal"
            from="Star Promenade"
            xref-link="a2/all_4_all_8"
-           xref-title="All 8 (A-1) Turn and Deal"
+           xref-title="All 8 (A-2) Turn and Deal"
            xref-formation="Star Promenade"/>
 
   <tamxref title="All 8 Turn and Deal"
            from="Reverse Star Promenade"
            xref-link="a2/all_4_all_8"
-           xref-title="All 8 (A-1) Turn and Deal"
+           xref-title="All 8 (A-2) Turn and Deal"
            xref-formation="Reverse Star Promenade"/>
 
 </tamination>

--- a/assets/a1/wheel_thru.xml
+++ b/assets/a1/wheel_thru.xml
@@ -117,7 +117,7 @@
 
   <tamxref title="All 8 Wheel Thru" group=" "
            xref-link="a2/all_4_all_8"
-           xref-title="All 8 (A-1) Wheel Thru"/>
+           xref-title="All 8 (A-2) Wheel Thru"/>
 
   <tam title="Left Wheel Thru"
        from="Facing Couples"
@@ -214,6 +214,6 @@
 
   <tamxref title="All 8 Left Wheel Thru" group=" "
            xref-link="a2/all_4_all_8"
-           xref-title="All 8 (A-1) Left Wheel Thru"/>
+           xref-title="All 8 (A-2) Left Wheel Thru"/>
 
 </tamination>


### PR DESCRIPTION
I _think_ this is the appropriate change but I'm not 100% sure. Since All 8 and All 4 Couples appear in the A-2 checklist, I think the label is supposed to say "A-2". Let me know if I'm misunderstanding the intention of a label like "All 8 (A-1) Lockit".