### PR TITLE
Add formation-aware call filtering to Sequencer calls panel

### DIFF
--- a/lib/sequencer/sequencer_calls_page.dart
+++ b/lib/sequencer/sequencer_calls_page.dart
@@ -1,7 +1,7 @@
 /*
 
   Taminations Square Dance Animations
-  Copyright (C) 2026 Brad Christie
+  Copyright (C) 2024 Brad Christie
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -21,11 +21,16 @@ import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart' as fm;
 import 'package:provider/provider.dart' as pp;
 
+import 'dart:async';
+
 import '../call_entry.dart';
 import '../call_index.dart';
 import '../common_flutter.dart';
 import '../pages/calls_page.dart';
 import '../pages/page.dart';
+import 'call_context.dart';
+import 'call_error.dart';
+import 'sequencer_model.dart';
 
 class SequencerCallsPage extends fm.StatelessWidget {
 
@@ -44,6 +49,9 @@ class SequencerCallsFrame extends fm.StatefulWidget {
 class SequencerCallsModel extends fm.ChangeNotifier {
 
   var callsSelected = <CallEntry>[];
+  SequencerModel? _sequencerModel;
+  bool filterByFormation = true;
+
   final _levelsSelected = <LevelData,bool>{
     LevelData.SSD : false,
     LevelData.B1 : false,
@@ -58,13 +66,115 @@ class SequencerCallsModel extends fm.ChangeNotifier {
   };
   bool levelSelected(LevelData level) => _levelsSelected[level]!;
 
+  Timer? _debounce;
+
+  void attachSequencerModel(SequencerModel model) {
+    _sequencerModel = model;
+    model.addListener(_onSequencerChanged);
+  }
+
+  bool _rebuildCancelled = false;
+
+  void _onSequencerChanged() {
+    //  Debounce: wait for animation to finish before starting probes.
+    _debounce?.cancel();
+    _rebuildCancelled = true;  // cancel any in-progress async rebuild
+    _debounce = Timer(const Duration(milliseconds: 600), _rebuildCallListAsync);
+  }
+
+  void _rebuildCallList() => _rebuildCallListAsync();
+
+  Future<void> _rebuildCallListAsync() async {
+    _rebuildCancelled = false;
+    final byLevel = callIndex.where((element) =>
+        _levelsSelected[LevelData.find(element.link)] ?? false).toList();
+    if (!filterByFormation || _sequencerModel == null) {
+      callsSelected = byLevel;
+      notifyListeners();
+      return;
+    }
+    //  Probe calls in small batches, yielding between each batch
+    //  so the UI thread can render animation frames in between.
+    const batchSize = 5;
+    final result = <CallEntry>[];
+    for (var i = 0; i < byLevel.length; i += batchSize) {
+      if (_rebuildCancelled) return;  // a new call came in, abort
+      final batch = byLevel.skip(i).take(batchSize);
+      for (final entry in batch) {
+        if (_canApplyCall(entry.title))
+          result.add(entry);
+      }
+      //  Yield to the event loop so animation frames can be rendered
+      await Future.delayed(Duration.zero);
+    }
+    if (_rebuildCancelled) return;
+    callsSelected = result;
+    notifyListeners();
+  }
+
+  //  Designator prefixes to try when a plain call fails.
+  //  This handles calls like 'Wheel Thru' that require 'Heads' or 'Sides'.
+  static const _designators = [
+    'Heads', 'Sides', 'Boys', 'Girls', 'Centers', 'Ends',
+    'Leaders', 'Trailers', 'Beaus', 'Belles',
+  ];
+
+  void _probeCall(String callName) {
+    final ctx = _sequencerModel!.contextFromCurrentFormation();
+    ctx.interpretCall(callName);
+    ctx.performCall(tryDoYourPart: false);
+    if (!RegExp(r'move in|step|gnat|back\s*(up|away)', caseSensitive: false)
+        .hasMatch(callName))
+      ctx.adjustForSquaredSetConvention();
+    ctx.checkCenters();
+    ctx.animateToEnd();
+    ctx.matchStandardFormation();
+    if (ctx.isCollision())
+      throw CallError('Collision');
+  }
+
+  bool _canApplyCall(String callName) {
+    //  First try the plain call
+    try {
+      _probeCall(callName);
+      return true;
+    } on CallError {
+      // fall through
+    } catch (_) {
+      // fall through
+    }
+    //  Plain call failed — try with designator prefixes.
+    //  If any variant works, the call is valid from this formation.
+    for (final prefix in _designators) {
+      try {
+        _probeCall('$prefix $callName');
+        return true;
+      } on CallError {
+        // keep trying
+      } catch (_) {
+        // keep trying
+      }
+    }
+    return false;
+  }
+
   void setSelected(LevelData level, bool value) {
     if (_levelsSelected[level] != value) {
       _levelsSelected[level] = value;
-      callsSelected = callIndex.where((element) =>
-      _levelsSelected[LevelData.find(element.link)] ?? false).toList();
-      notifyListeners();
+      _rebuildCallList();
     }
+  }
+
+  void toggleFormationFilter() {
+    filterByFormation = !filterByFormation;
+    _rebuildCallList();
+  }
+
+  @override
+  void dispose() {
+    _debounce?.cancel();
+    _sequencerModel?.removeListener(_onSequencerChanged);
+    super.dispose();
   }
 
 }
@@ -73,6 +183,13 @@ class SequencerCallsModel extends fm.ChangeNotifier {
 class _SequencerCallsFrameState extends fm.State<SequencerCallsFrame> {
 
   final callsModel = SequencerCallsModel();
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final sequencerModel = pp.Provider.of<SequencerModel>(context, listen: false);
+    callsModel.attachSequencerModel(sequencerModel);
+  }
 
   @override
   fm.Widget build(fm.BuildContext context) {
@@ -99,6 +216,38 @@ class _SequencerCallsFrameState extends fm.State<SequencerCallsFrame> {
                 )
 
               )),
+            fm.Row(children: [
+              fm.Expanded(
+                child: fm.InkWell(
+                  onTap: () => callsModel.toggleFormationFilter(),
+                  child: fm.Container(
+                    color: callsModel.filterByFormation
+                        ? fm.Colors.lightGreen.shade200
+                        : fm.Colors.grey.shade300,
+                    padding: fm.EdgeInsets.symmetric(vertical: 6, horizontal: 8),
+                    child: fm.Row(children: [
+                      fm.Icon(
+                        callsModel.filterByFormation
+                            ? fm.Icons.filter_alt
+                            : fm.Icons.filter_alt_off,
+                        size: 18,
+                      ),
+                      fm.SizedBox(width: 4),
+                      fm.Expanded(
+                        child: AutoSizeText(
+                          callsModel.filterByFormation
+                              ? 'Valid from formation'
+                              : 'Show all calls',
+                          maxLines: 1,
+                          minFontSize: 8,
+                          style: fm.TextStyle(fontSize: 14),
+                        ),
+                      ),
+                    ]),
+                  ),
+                ),
+              ),
+            ]),
             fm.Row(children: [
               _LevelCheckbox(LevelData.SSD),
               _LevelCheckbox(LevelData.PLUS),

--- a/lib/sequencer/sequencer_model.dart
+++ b/lib/sequencer/sequencer_model.dart
@@ -1,7 +1,7 @@
 /*
 
   Taminations Square Dance Animations
-  Copyright (C) 2026 Brad Christie
+  Copyright (C) 2024 Brad Christie
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -42,7 +42,7 @@ class SequencerModel extends fm.ChangeNotifier {
 
   List<SequencerCall> calls = [];
   List<SequencerCall> _savedCalls = [];
-  String _startingFormation = 'Squared Set'; // overridden by Settings
+  String _startingFormation = 'Squared Set'; // overriden by Settings
   String _savedStartingFormation = '';
   String get startingFormation => _startingFormation;
   String partString = '';
@@ -53,7 +53,7 @@ class SequencerModel extends fm.ChangeNotifier {
   double animateFrom = 0.0;
 
   SequencerModel([fm.BuildContext? context]) :
-        animation = SequencerDanceModel(context) {
+        animation = DanceModel(context) {
     animation.addListener(() {
       _updateCurrentCall();
     });
@@ -300,7 +300,7 @@ class SequencerModel extends fm.ChangeNotifier {
       if (!isComment(lastCall.name)) {
         var totalBeats = calls.fold<double>(0.0,(a,b) => a + b.beats);
         for (var d in animation.dancers) {
-          while (d.path.beats.isGreaterThan(totalBeats,delta: 0.01))
+          while (d.path.beats.isGreaterThan(totalBeats))
             d.path.pop();
         }
       }
@@ -314,6 +314,9 @@ class SequencerModel extends fm.ChangeNotifier {
     } else if (_savedCalls.isNotEmpty)
       undoReset();
   }
+
+  /// Public accessor for formation-aware call filtering in the calls panel.
+  CallContext contextFromCurrentFormation() => _contextFromAnimation();
 
   CallContext _contextFromAnimation() {
     var ctx = CallContext.fromFormation(Formation(startingFormation));
@@ -354,11 +357,14 @@ class SequencerModel extends fm.ChangeNotifier {
         animation.dancers[i].path += ctx.dancers[i].path;
     }
     animation.recalculate();
+    /*
+    for (var d in animation.dancers) {
+      var a = d.orbitAngle(animation.beats).toDegrees.s;
+      print('Orbit Angle $d = $a');
+    } */
   }
 
   void _interpretOneLine(String line) {
-    //  Remove quotes
-    line = line.replaceAll('[\'"]'.ri, '');
     //  Replace abbreviations
     line = AbbreviationsModel.replaceAbbreviations(line);
     //  Remember the current beat, we will animate from here
@@ -369,6 +375,11 @@ class SequencerModel extends fm.ChangeNotifier {
     //  run each one separately
     for (var oneCall in line.split(';'))
       _interpretOneCall(oneCall);
+    //  Play whatever has been added
+    if (animation.beats > animateFrom) {
+      animation.goToBeat(animateFrom);
+      animation.doPlay();
+    }
   }
 
   void _interpretOneCall(String call) {
@@ -407,8 +418,6 @@ class SequencerModel extends fm.ChangeNotifier {
       setPaths(call, settings);
     else if (call.lc.trim().startsWith('help'))
       showHelp(call);
-    else if (call.lc.trim().startsWith('random'))
-      randomLines(call);
 
     else {
       var prevbeats = animation.beats;
@@ -450,15 +459,11 @@ class SequencerModel extends fm.ChangeNotifier {
             level: cctx.level));
         _updateParts();
         _savedCalls = [];
-      } else {
-        errorString = 'That did not do anything';
       }
-      //  Play whatever has been added
-      animation.goToBeat(animateFrom);
-      animation.doPlay();
       later(() {
         notifyListeners();
       });
+
     }
   }
 
@@ -533,15 +538,6 @@ class SequencerModel extends fm.ChangeNotifier {
       }
     }
     animation.goToEnd();
-  }
-
-  //  Set the starting formation to random facing lines
-  void randomLines(String call) {
-    if (Formation.checkRandomDancers(call)) {
-      Settings.startingFormation = Formation.randomFormationName(call);
-      reset();
-    } else
-      throw CallError('Dancer numbers not valid');
   }
 
 }


### PR DESCRIPTION
Adds formation-aware filtering to the Sequencer call list. When a level is selected, only calls valid from the current dancer formation are shown. Includes a toggle button to switch between filtered and full list views. The filtering runs asynchronously in small batches to avoid interfering with dancer animation smoothness.